### PR TITLE
change backtick to double colon

### DIFF
--- a/src/Cpu/Cpu.php
+++ b/src/Cpu/Cpu.php
@@ -110,7 +110,7 @@ class Cpu
                 return new AddrOrDataAndAdditionalCycle($addr & 0xFFFF, 0);
             default:
                 echo($mode);
-                throw new \Exception(`Unknown addressing $mode detected.`);
+                throw new \Exception("Unknown addressing $mode detected.");
         }
     }
 


### PR DESCRIPTION
-> Exception will cause shell execution error like
Unknown: not found